### PR TITLE
use configuration file for ignore/needed directories

### DIFF
--- a/scripts/init.cfg
+++ b/scripts/init.cfg
@@ -1,0 +1,3 @@
+[init_workspace]
+ignore_dirs = catkin, scripts, .git, tmp
+needed_dirs = appctl, interactivespaces_msgs, lg_cms_director

--- a/scripts/init_workspace
+++ b/scripts/init_workspace
@@ -33,7 +33,7 @@ def parse_config():
     """
     Sets globals which are better set in a config file
     """
-    config_file = 'setup.cfg'
+    config_file = 'scripts/init.cfg'
     if not os.path.exists(config_file):
         print 'WARNING, no %s found, using possibly outdated configuration' % config_file
         return # rely on hard coded values... maybe an exception would work

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,3 @@
 ignore = E501
 exclude = .git,catkin/
 count = true
-
-[init_workspace]
-ignore_dirs = catkin, scripts, .git, tmp
-needed_dirs = appctl, interactivespaces_msgs, lg_cms_director


### PR DESCRIPTION
Also start requiring lg_cms_director to be included.

Waiting on a green light from @mvollrath to ok the use of setup.cfg for other configuration items than `pep8` stuff.
