### PR TITLE
lg_sv: parameterize tilt

### DIFF
--- a/lg_sv/webapps/client/js/main.js
+++ b/lg_sv/webapps/client/js/main.js
@@ -56,6 +56,9 @@ function initialize() {
     var viewportFOV = fieldOfView / canvasRatio;
     var radianOffset = toRadians(viewportFOV * yawOffset);
     var htr = [povQuaternion.z, povQuaternion.x, 0];
+    if (! shouldTilt) {
+      htr[1] = 0;
+    }
     var transformedHTR = transformHTR(htr, radianOffset);
     var roll = -transformedHTR[2];
     var pov = {


### PR DESCRIPTION
Very simple, but maybe @mvollrath might have something to say about it. Like a way to optimize the `transformHTR()` method. This works well though. Also we should think about whether we want tilt to be off by default (currently this way) or on by default.
