### PR TITLE
managed_browser: ros paramaterized command flags

### DIFF
--- a/lg_common/README.md
+++ b/lg_common/README.md
@@ -135,6 +135,7 @@ A `ManagedApplication` subclass for running a browser.
 * `geometry` [WindowGeometry] - Where to put the window. Optional.
 * `binary` [string] - Absolute path to the browser binary. Default: `/usr/bin/google-chrome`
 * `remote_debugging_port` [int] - Specify a remote debugging port. If not provided, a port will be assigned.
+* `command_line_args` [string] - A large string of command line arguments for chrome.
 
 All other keyword arguments are passed on directly to the command line.
 

--- a/lg_common/scripts/static_browser.py
+++ b/lg_common/scripts/static_browser.py
@@ -15,6 +15,7 @@ if __name__ == '__main__':
 
     geometry = ManagedWindow.get_viewport_geometry()
     url = rospy.get_param('~url', None)
+    command_line_args = rospy.get_param('~command_line_args', '')
     scale_factor = rospy.get_param('~force_device_scale_factor', 1)
     debug_port = rospy.get_param('~debug_port', 10000)
     user_agent = rospy.get_param(
@@ -41,6 +42,7 @@ if __name__ == '__main__':
     browser = ManagedBrowser(
         geometry=geometry,
         url=url,
+        command_line_args=command_line_args,
         force_device_scale_factor=scale_factor,
         debug_port=debug_port,
         user_agent=user_agent

--- a/lg_common/scripts/touchscreen.py
+++ b/lg_common/scripts/touchscreen.py
@@ -19,6 +19,7 @@ if __name__ == '__main__':
     geometry = ManagedWindow.get_viewport_geometry()
 
     url_base = rospy.get_param('~url_base', 'http://lg-head/ros_touchscreens/ts/')
+    command_line_args = rospy.get_param('~command_line_args', '')
     # TODO (wz) director_host and director_port should be global
 
     director_host = rospy.get_param('~director_host', '42-a')
@@ -86,6 +87,7 @@ if __name__ == '__main__':
     browser = ManagedBrowser(
         geometry=geometry,
         url=url,
+        command_line_args=command_line_args,
         force_device_scale_factor=scale_factor,
         debug_port=debug_port,
         user_agent=user_agent

--- a/lg_common/src/lg_common/managed_browser.py
+++ b/lg_common/src/lg_common/managed_browser.py
@@ -27,7 +27,7 @@ DEFAULT_ARGS = [
 class ManagedBrowser(ManagedApplication):
     def __init__(self, url=None, slug=None, kiosk=True, geometry=None,
                  binary=DEFAULT_BINARY, remote_debugging_port=None, app=False,
-                 shell=True, **kwargs):
+                 shell=True, command_line_args='', **kwargs):
 
         cmd = [binary]
 
@@ -59,6 +59,8 @@ class ManagedBrowser(ManagedApplication):
         cmd.append('--crash-dumps-dir={}/crashes'.format(tmp_dir))
 
         cmd.extend(DEFAULT_ARGS)
+        if command_line_args != '':
+            cmd.extend(command_line_args)
 
         # All remaining kwargs are mapped to command line args.
         # _ is replaced with -.


### PR DESCRIPTION
Now node defs can specify extra command line flags to use.