### PR TITLE
Reduce virtual spacenav drift

### DIFF
--- a/lg_nav_to_device/src/lg_nav_to_device/device_writer.py
+++ b/lg_nav_to_device/src/lg_nav_to_device/device_writer.py
@@ -13,39 +13,31 @@ class DeviceWriter:
         product = 0
         version = 273
         bustype = 3
-        common_abs = AbsInfo(value=0, min=0, max=32767, fuzz=0, flat=0,
-                             resolution=0)
-        tracking_abs = AbsInfo(value=0, min=0, max=65535, fuzz=0, flat=0,
-                               resolution=0)
-        slot_abs = AbsInfo(value=0, min=0, max=9, fuzz=0, flat=0, resolution=0)
-        spacenav_events = {
-            1L: [256L, 257L],
-            2L: [0L, 1L, 2L, 3L, 4L, 5L],
-            # the abs values were stolen from the previous hardcoding in
-            # evdev_teleport, for some reason device.capabilities() did not
-            # show any abs values...
-            3L: [(e.ABS_X, common_abs),
-                 (e.ABS_Y, common_abs),
-                 (e.ABS_MT_POSITION_X, common_abs),
-                 (e.ABS_MT_POSITION_Y, common_abs),
-                 (e.ABS_MT_TRACKING_ID, tracking_abs),
-                 (e.ABS_MT_SLOT, slot_abs)],
-            4L: [4L],
-            17L: [8L]
+        caps = {
+            e.EV_KEY: [e.BTN_0, e.BTN_1],
+            e.EV_REL: [e.REL_X, e.REL_Y, e.REL_Z, e.REL_RX, e.REL_RY, e.REL_RZ],
         }
         device_name = 'Virtual SpaceNav'
         self.state = True
-        self.ui = UInput(spacenav_events, vendor=vendor, product=product,
+        self.ui = UInput(caps, vendor=vendor, product=product,
                          version=version, bustype=bustype, name=device_name)
 
     def make_event(self, data):
         if not self.state:
             return
+        for v in (data.linear, data.angular):
+            # We don't want to write zeroes because the real spacenav never does,
+            # instead write a small value inside Earth's gutter to prevent drift.
+            if v.x == 0:
+                v.x = 1.0 / self.scale
+            if v.y == 0:
+                v.y = 1.0 / self.scale
+            if v.z == 0:
+                v.z = 1.0 / self.scale
         # write some event to self.ui based off of the twist data
         _time = time.time()
         stime = int(_time)
         utime = int((float(_time) - stime) * 10 ** 6)
-        # linear and angular might need to be switched here...
         x = InputEvent(stime, utime, e.EV_REL, e.REL_X, -self.translate(data.linear.y))
         y = InputEvent(stime, utime, e.EV_REL, e.REL_Y, -self.translate(data.linear.x))
         z = InputEvent(stime, utime, e.EV_REL, e.REL_Z, -self.translate(data.linear.z))


### PR DESCRIPTION
Instead of writing zeroes (which are ignored), write a small value inside the gutter.

This will probably behave poorly for any application besides Earth.