### PR TITLE
Normalize MPlayer window positioning

### DIFF
--- a/lg_common/src/lg_common/managed_browser.py
+++ b/lg_common/src/lg_common/managed_browser.py
@@ -52,7 +52,6 @@ class ManagedBrowser(ManagedApplication):
 
         self.relay = TCPRelay(self.debug_port, remote_debugging_port)
 
-
         if log_stderr:
             cmd.append('--enable-logging=stderr')
         else:

--- a/lg_media/src/lg_media/mplayer_pool.py
+++ b/lg_media/src/lg_media/mplayer_pool.py
@@ -61,10 +61,9 @@ class ManagedMplayer(ManagedApplication):
         if self.respawn:
             cmd.extend(["-loop", "0"])
 
-        cmd.extend(['-geometry', '{0}x{1}+{2}+{3}'.format(self.window.geometry.width,
-                                                          self.window.geometry.height,
-                                                          self.window.geometry.x,
-                                                          self.window.geometry.y)])
+        cmd.extend(['-geometry', '{0}x{1}'.format(self.window.geometry.width,
+                                                  self.window.geometry.height)])
+        cmd.extend(["-name", str(self.slug)])
         cmd.extend(["-input", "file=%s" % self.fifo_path])
         cmd.extend([self.url])
         rospy.logdebug("Mplayer POOL: mplayer cmd: %s" % cmd)
@@ -197,8 +196,8 @@ class MplayerPool(object):
                                   height=incoming_mplayer.geometry.height)
 
         mplayer_window = ManagedWindow(geometry=geometry,
-                                       w_instance="Mplayer \\({}\\)".format(mplayer_id),
-                                       w_class="Mplayer \\({}\\)".format(mplayer_id))
+                                       w_instance=str(mplayer_id),
+                                       w_class="MPlayer")
 
         if incoming_mplayer.on_finish == "nothing" or incoming_mplayer.on_finish == "close":
             respawn = False


### PR DESCRIPTION
The ManagedMplayer's ManagedWindow was not detecting its application window.  By passing the instance name as -name to mplayer, the application will set its classname and awesome can filter it.

The observed problem was that with the recent addition of -loop 0, the
video kept moving horizontally across the screen.  This is presumably an
artifact of setting +x+y in -geometry, so that redundant setting was removed.

Because awesome was not setting the window dimensions as expected, width
and height are still set in -geometry.  This is presumably MPlayer using
size hints or something to force expected dimensions for direct
rendering.