### PR TITLE
Add float_pointer param for touch receiver

### DIFF
--- a/lg_mirror/README.md
+++ b/lg_mirror/README.md
@@ -116,6 +116,7 @@ Creates a uinput clone of the sending device, maps it to a viewport, and conditi
 #### Parameters
 
 * `viewport` [str] - The viewport to be managed by this receiver.
+* `float_pointer` [bool] - Float the xinput device pointer. This prevents interference with Chrome when there are multiple receivers on the same DISPLAY. **This may be later deprecated by activity-specific configuration.** Default: `false`
 
 #### Subscribed Topics
 

--- a/lg_mirror/include/lg_mirror/uinput_device.h
+++ b/lg_mirror/include/lg_mirror/uinput_device.h
@@ -28,6 +28,7 @@ class UinputDevice {
 
     bool Init(const lg_mirror::EvdevDeviceInfoResponse& info);
     bool WaitForXinput();
+    bool FloatPointer() const;
 
     void HandleEventMessage(const lg_mirror::EvdevEvents::Ptr& msg);
 

--- a/lg_mirror/src/receiver.cpp
+++ b/lg_mirror/src/receiver.cpp
@@ -10,6 +10,7 @@
 
 const char* DEVICE_NAME_BASE = "Virtual Touchscreen (%s)";
 const char* VIEWPORT_PARAM = "viewport";
+const char* FLOAT_POINTER_PARAM = "float_pointer";
 
 using lg_mirror::DEVICE_INFO_SERVICE;
 using lg_mirror::TOUCH_ROUTE_TOPIC;
@@ -27,6 +28,7 @@ int main(int argc, char** argv) {
 
   ros::NodeHandle n("~");
 
+  bool float_pointer = false;
   std::string viewport_name;
   std::string device_name;
   std::string viewport_geometry;
@@ -34,6 +36,7 @@ int main(int argc, char** argv) {
 
   /* grab parameters */
 
+  n.param<bool>(FLOAT_POINTER_PARAM, float_pointer, false);
   if (!n.getParam(VIEWPORT_PARAM, viewport_name)) {
     ROS_ERROR("'viewport' parameter is required");
     fail();
@@ -83,6 +86,15 @@ int main(int argc, char** argv) {
   if (!uinput_device.WaitForXinput()) {
     ROS_ERROR("xinput query was cancelled");
     fail();
+  }
+
+  /* float the pointer if appropriate */
+
+  if (float_pointer) {
+    if (!uinput_device.FloatPointer()) {
+      ROS_ERROR("failed to float pointer");
+      fail();
+    }
   }
 
   /* instantiate an event relay */

--- a/lg_mirror/src/uinput_device.cpp
+++ b/lg_mirror/src/uinput_device.cpp
@@ -183,6 +183,18 @@ bool UinputDevice::WaitForXinput() {
 }
 
 /**
+ * \brief Floats the xinput device pointer.
+ * \return true if successful.
+ */
+bool UinputDevice::FloatPointer() const {
+  std::ostringstream cmd;
+  cmd << "/usr/bin/xinput float '" << device_name_ << "'";
+
+  int status = system(cmd.str().c_str());
+  return status == 0;
+}
+
+/**
  * \brief Handles a ROS message containing a vector of events.
  *
  * Implicitly writes a SYN event after the incoming events.


### PR DESCRIPTION
Allows for floating the pointer to prevent interference between multiple pointers in Chrome.