### PR TITLE
Add optional support for Chrome --kiosk windows

### DIFF
--- a/lg_common/src/lg_common/awesome.py
+++ b/lg_common/src/lg_common/awesome.py
@@ -65,7 +65,7 @@ def get_rule_pattern(window):
     return ', '.join(patternized)
 
 
-def get_properties(window):
+def get_properties(window, chrome_kiosk_workaround=False):
     """Get a properties string to converge the window to its state.
 
     Args:
@@ -78,9 +78,10 @@ def get_properties(window):
         "border_width = 0",
         "size_hints_honor = false",
         "floating = true",
+        # Chrome Kiosk Workaround:
         # Trick Chrome in kiosk mode by setting fullscreen to true here.
         # In the callback we will set it to false.
-        "fullscreen = true",
+        "fullscreen = {}".format('true' if chrome_kiosk_workaround else 'false'),
         "maximized = false",
         "hidden = {}".format('false' if window.is_visible else 'true'),
         "minimized = {}".format('false' if window.is_visible else 'true'),
@@ -112,7 +113,7 @@ def get_callback(window):
         return ""
 
 
-def get_entry(window):
+def get_entry(window, chrome_kiosk_workaround=False):
     """Get the full awesome (awful) rule that will converge the window.
 
     Args:
@@ -122,7 +123,7 @@ def get_entry(window):
         str: awesome rule for the window.
     """
     rule = get_rule_pattern(window)
-    properties = get_properties(window)
+    properties = get_properties(window, chrome_kiosk_workaround)
     callback = get_callback(window)
     return "{ rule = { %s }, properties = { %s }, callback = %s }" % (rule, properties, callback)
 
@@ -147,7 +148,7 @@ def get_subtractive_script(window):
     )
 
 
-def get_additive_script(window):
+def get_additive_script(window, chrome_kiosk_workaround=False):
     """Get a script that will add an awesome (awful) rule for the window.
 
     Args:
@@ -156,7 +157,7 @@ def get_additive_script(window):
     Returns:
         str: Lua code to add the window rule.
     """
-    entry = get_entry(window)
+    entry = get_entry(window, chrome_kiosk_workaround)
     return "table.insert(awful.rules.rules, 1, {entry})".format(entry=entry)
 
 
@@ -174,7 +175,7 @@ def get_apply_script(window):
     return "for k,c in pairs(client.get()) do if awful.rules.match(c, {%s}) then awful.rules.apply(c) end end" % pattern
 
 
-def get_script(window):
+def get_script(window, chrome_kiosk_workaround=False):
     """Combine scripts to form a mega-script that fixes everything.
 
     Args:
@@ -186,7 +187,7 @@ def get_script(window):
     return ' '.join([
         "local awful = require('awful') awful.rules = require('awful.rules')",
         get_subtractive_script(window),
-        get_additive_script(window),
+        get_additive_script(window, chrome_kiosk_workaround),
         get_apply_script(window)
     ])
 

--- a/lg_common/src/lg_common/managed_browser.py
+++ b/lg_common/src/lg_common/managed_browser.py
@@ -115,7 +115,7 @@ class ManagedBrowser(ManagedApplication):
         # Different versions of Chrome use different window instance names.
         # Matching the tmp_dir should work for all of them.
         w_instance = '\\({}\\)'.format(self.tmp_dir)
-        window = ManagedWindow(w_instance=w_instance, geometry=geometry, chrome_kiosk_workaround=True)
+        window = ManagedWindow(w_instance=w_instance, geometry=geometry, chrome_kiosk_workaround=kiosk)
 
         rospy.logdebug("Command {}".format(cmd))
 

--- a/lg_common/src/lg_common/managed_browser.py
+++ b/lg_common/src/lg_common/managed_browser.py
@@ -115,7 +115,7 @@ class ManagedBrowser(ManagedApplication):
         # Different versions of Chrome use different window instance names.
         # Matching the tmp_dir should work for all of them.
         w_instance = '\\({}\\)'.format(self.tmp_dir)
-        window = ManagedWindow(w_instance=w_instance, geometry=geometry)
+        window = ManagedWindow(w_instance=w_instance, geometry=geometry, chrome_kiosk_workaround=True)
 
         rospy.logdebug("Command {}".format(cmd))
 

--- a/lg_common/src/lg_common/managed_window.py
+++ b/lg_common/src/lg_common/managed_window.py
@@ -9,12 +9,13 @@ import awesome
 
 class ManagedWindow(object):
     def __init__(self, w_name=None, w_class=None, w_instance=None,
-                 geometry=None, visible=True):
+                 geometry=None, visible=True, chrome_kiosk_workaround=False):
         self.w_name = w_name
         self.w_class = w_class
         self.w_instance = w_instance
         self.geometry = geometry
         self.is_visible = visible
+        self.chrome_kiosk_workaround = chrome_kiosk_workaround
         self.lock = threading.RLock()
         self.proc = None
 
@@ -72,7 +73,7 @@ class ManagedWindow(object):
         with self.lock:
             cmd = []
             cmd.append('echo "{}" | /usr/bin/awesome-client'.format(
-                awesome.get_script(self)
+                awesome.get_script(self, chrome_kiosk_workaround=self.chrome_kiosk_workaround)
             ))
         return cmd
 


### PR DESCRIPTION
Using this workaround all the time was breaking other apps, so only use
it when launching a browser.