### PR TITLE
Street View multi-panel support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,9 +25,9 @@ RUN \
         --from-paths /home/galadmin/src/lg_ros_nodes/catkin/src \
         --ignore-src \
         --rosdistro indigo \
-        -y ;\
-    catkin_make ;\
-    catkin_make -DCMAKE_INSTALL_PREFIX=/opt/ros/indigo install;\
+        -y && \
+    catkin_make && \
+    catkin_make -DCMAKE_INSTALL_PREFIX=/opt/ros/indigo install && \
     source /home/galadmin/src/lg_ros_nodes/catkin/devel/setup.bash && \
     sudo chown -R ${TEST_USER}:${TEST_USER} ${HOME}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN \
     source /opt/ros/indigo/setup.bash && \
     /ros_entrypoint.sh ./scripts/init_workspace -a $HOME/src/appctl && \
     cd ${PROJECT_ROOT}/catkin/ && \
+    apt-get update && \
     rosdep init &&\
     rosdep update && \
     sudo rosdep install \
@@ -29,7 +30,8 @@ RUN \
     catkin_make && \
     catkin_make -DCMAKE_INSTALL_PREFIX=/opt/ros/indigo install && \
     source /home/galadmin/src/lg_ros_nodes/catkin/devel/setup.bash && \
-    sudo chown -R ${TEST_USER}:${TEST_USER} ${HOME}
+    sudo chown -R ${TEST_USER}:${TEST_USER} ${HOME} && \
+    rm -rf /var/lib/apt/lists/*
 
 # by default let's run tests
 CMD cd ${PROJECT_ROOT}/catkin && \

--- a/lg_sv/CMakeLists.txt
+++ b/lg_sv/CMakeLists.txt
@@ -3,9 +3,17 @@ project(lg_sv)
 
 find_package(catkin REQUIRED COMPONENTS
   rospy
-  )
+  message_generation
+)
 
 catkin_python_setup()
+
+add_service_files(
+  FILES
+  PanoIdState.srv
+)
+
+generate_messages()
 
 catkin_package()
 

--- a/lg_sv/launch/sv.launch
+++ b/lg_sv/launch/sv.launch
@@ -1,7 +1,7 @@
 <launch>
-  <param name="/viewport/left_one" value="450x800+0+0" />
-  <param name="/viewport/center" value="450x800+460+0" />
-  <param name="/viewport/right_one" value="450x800+920+0" />
+  <arg name="kiosk" default="true" />
+
+  <param name="/viewport/triple" value="1920x800+0+0" />
 
   <node name="dev_webserver" pkg="lg_common" type="dev_webserver.py" />
   <node name="rosbridge" pkg="rosbridge_server" type="rosbridge_websocket" />
@@ -12,22 +12,11 @@
   <node name="spacenav_wrapper" pkg="spacenav_wrapper" type="spacenav_wrap.py" />
 
   <node name="sv_center" pkg="lg_sv" type="launcher.py">
-    <param name="viewport" value="center"/>
+    <param name="kiosk" value="$(arg kiosk)"/>
+    <param name="viewport" value="triple"/>
     <param name="depend_on_rosbridge" value="true"/>
     <param name="depend_on_webserver" value="true"/>
-    <param name="yaw_offset" value="0"/>
+    <param name="yaw_offsets" value="-1,0,1"/>
     <param name="show_links" value="true"/>
-  </node>
-  <node name="sv_left_one" pkg="lg_sv" type="launcher.py">
-    <param name="depend_on_webserver" value="true"/>
-    <param name="depend_on_rosbridge" value="true"/>
-    <param name="viewport" value="left_one"/>
-    <param name="yaw_offset" value="-1"/>
-  </node>
-  <node name="sv_right_one" pkg="lg_sv" type="launcher.py">
-    <param name="depend_on_webserver" value="true"/>
-    <param name="depend_on_rosbridge" value="true"/>
-    <param name="viewport" value="right_one"/>
-    <param name="yaw_offset" value="1"/>
   </node>
 </launch>

--- a/lg_sv/package.xml
+++ b/lg_sv/package.xml
@@ -12,6 +12,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>rospy</build_depend>
+  <build_depend>message_generation</build_depend>
   <run_depend>rospy</run_depend>
   <run_depend>lg_common</run_depend>
   <run_depend>spacenav_node</run_depend>

--- a/lg_sv/scripts/launcher.py
+++ b/lg_sv/scripts/launcher.py
@@ -28,6 +28,7 @@ def main():
     show_links = str(rospy.get_param('~show_links', False)).lower()
     show_attribution = str(rospy.get_param('~show_attribution', False)).lower()
     yaw_offset = float(rospy.get_param('~yaw_offset', 0))
+    yaw_offsets = str(rospy.get_param('~yaw_offsets', yaw_offset))
     leader = str(rospy.get_param('~leader', 'false'))
     tilt = str(rospy.get_param('~tilt', 'false'))
     depend_on_webserver = rospy.get_param('~depend_on_webserver', False)
@@ -37,6 +38,7 @@ def main():
     rosbridge_secure = rospy.get_param('~rosbridge_secure', 'false')
     zoom = str(rospy.get_param('~zoom', 'false')).lower()
     initial_zoom = rospy.get_param('~initial_zoom', 3)
+    kiosk = rospy.get_param('~kiosk', True)
 
     # put parameters into one big url
     url = add_url_params(url,
@@ -47,7 +49,7 @@ def main():
                          showLinks=show_links,
                          showAttribution=show_attribution,
                          leader=leader,
-                         yawOffset=yaw_offset,
+                         yawOffsets=yaw_offsets,
                          tilt=tilt,
                          rosbridgeHost=rosbridge_host,
                          rosbridgePort=rosbridge_port,
@@ -65,7 +67,7 @@ def main():
 
     # create the managed browser
     slug = server_type + "__" + "_fov-" + str(field_of_view) + "__" + "_yaw-" + str(yaw_offset) + "__" + "_pitch-" + str(pitch_offset)
-    managed_browser = ManagedAdhocBrowser(url=url, geometry=geometry, slug=slug)
+    managed_browser = ManagedAdhocBrowser(url=url, geometry=geometry, slug=slug, kiosk=kiosk)
 
     # set initial state
     state = ApplicationState.STOPPED

--- a/lg_sv/scripts/server.py
+++ b/lg_sv/scripts/server.py
@@ -12,6 +12,7 @@ from sensor_msgs.msg import Joy
 from math import atan2, cos, sin, pi
 from lg_sv import PanoViewerServer, NearbyPanos, NearbyStreetviewPanos
 from lg_common.helpers import run_with_influx_exception_handler
+from lg_sv.srv import PanoIdState
 
 
 # spacenav_node -> /spacenav/twist -> handle_spacenav_msg:
@@ -82,6 +83,7 @@ def main():
                      server.handle_raw_metadata_msg)
     rospy.Subscriber('/spacenav/joy', Joy, server.handle_joy)
     rospy.Subscriber('/%s/tilt_snappy' % server_type, Bool, server.handle_tilt_snappy)
+    rospy.Service('/streetview/panoid_state', PanoIdState, server.get_panoid)
     make_soft_relaunch_callback(server.handle_soft_relaunch, groups=['streetview'])
 
     # This will translate director messages into /<server_type>/panoid messages

--- a/lg_sv/src/lg_sv/server.py
+++ b/lg_sv/src/lg_sv/server.py
@@ -220,6 +220,12 @@ class PanoViewerServer:
         """
         return self.nearby_panos.get_metadata()
 
+    def get_panoid(self, *args, **kwargs):
+        """
+        Get the current panoid
+        """
+        return self.panoid
+
     def pub_pov(self, pov):
         """
         Publishes the new pov after setting the instance variable

--- a/lg_sv/srv/PanoIdState.srv
+++ b/lg_sv/srv/PanoIdState.srv
@@ -1,0 +1,2 @@
+---
+string panoid

--- a/lg_sv/test/test_scene.py
+++ b/lg_sv/test/test_scene.py
@@ -5,7 +5,7 @@ from interactivespaces_msgs.msg import GenericMessage
 P_SANDIEGO = '1ZPwYtCwgW6bu7gi7n3B4Q'
 P_TEST = 'RJd2HuqmShMAAAQfCa3ulg'
 P_PHOTOSPHERE = 'F:-gVtvWrACv2k/Vnh0Vg8Z8YI/AAAAAAABLWA/a-AT4Wb8MD8'
-PANOID = P_TEST
+PANOID = P_SANDIEGO
 DIRECTOR_MESSAGE = """
 {
   "description": "bogus",

--- a/lg_sv/webapps/client/index.html
+++ b/lg_sv/webapps/client/index.html
@@ -8,14 +8,6 @@
     <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
     <link href='https://fonts.googleapis.com/css?family=Product+Sans:400,400i,700,700i' rel='stylesheet' type='text/css'>
     <style>
-        #map-canvas {
-            background-color: black;
-            height: 100%;
-            width: 100%;
-            margin: 0;
-            padding: 0;
-            padding-right: 0;
-        }
         html, body {
             height: 100%;
             margin: 0;
@@ -24,30 +16,6 @@
             position: relative;
             overflow: hidden;
             pointer-events: none;
-        }
-        #wrapper {
-            padding: 0;
-        }
-        #info {
-            position: absolute;
-            bottom: 4px; width: 100%;
-            font-family: 'Roboto', sans-serif;
-            font-size: 9pt;
-            font-weight: 600;
-            text-align: center;
-            margin: 0;
-            color: #dddddd;
-        }
-        #logo {
-            position: absolute;
-            bottom: 4px;
-            left: 4px;
-            font-family: 'Product Sans', sans-serif;
-            font-size: 14pt;
-            font-weight: 600;
-            font-stretch: ultra-expanded;
-            margin: 0;
-            color: #dddddd;
         }
     </style>
     <script src="../lib/common.js"></script>
@@ -66,11 +34,6 @@
     <script src="js/main.js"></script>
 </head>
 <body>
-    <div id="wrapper">
-        <div id="map-canvas"></div>
-    </div>
-    <div id="info"></div>
-    <div id="logo">Google</div>
 </body>
 </html>
 <!--

--- a/lg_sv/webapps/client/index.html
+++ b/lg_sv/webapps/client/index.html
@@ -1,10 +1,6 @@
 <html>
 <title>panoviewer</title>
 <head>
-    <script>
-        // Override devicePixelRatio before loading any scripts.
-        window.devicePixelRatio = 2.04;
-    </script>
     <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
     <link href='https://fonts.googleapis.com/css?family=Product+Sans:400,400i,700,700i' rel='stylesheet' type='text/css'>
     <style>

--- a/lg_sv/webapps/client/js/glenvironment.js
+++ b/lg_sv/webapps/client/js/glenvironment.js
@@ -1,10 +1,28 @@
 /**
- * A WebGL environment on top of the page with transparent background.
+ * A WebGL environment on top of an existing Element with transparent background.
  * @constructor
+ * @param {HTMLElement} container
  * @param {Number} hFov horizontal FOV in degrees
+ * @param {Number} yawOffset yaw offset in screens
  */
-var GLEnvironment = function(hFov) {
-  this.hFov_ = hFov;
+var GLEnvironment = function(container, hFov, yawOffset) {
+  /**
+   * The environment will be drawn on top of this container element.
+   * @type {HTMLElement}
+   */
+  this.container = container;
+
+  /**
+   * Horizontal FOV in degrees.
+   * @type {Number}
+   */
+  this.hFov = hFov;
+
+  /**
+   * Yaw offset in screens.
+   * @type {Number}
+   */
+  this.yawOffset = yawOffset;
 
   /**
    * @type {THREE.Scene}
@@ -21,19 +39,14 @@ var GLEnvironment = function(hFov) {
   });
   this.renderer.setClearColor(new THREE.Color(0x000000), 0);
 
-  /**
-   * @type {Element}
-   */
   this.canvas = this.renderer.domElement;
   this.canvas.style.position = 'absolute';
-  this.canvas.style.bottom = '0px';
-  this.canvas.style.left = '0px';
-  this.canvas.style.width = '100%';
-  this.canvas.style.height = '100%';
   this.canvas.style.zIndex = '99999';
+  this.canvas.style.top = '0px';
+  this.canvas.style.left = '0px';
   this.canvas.style.backgroundColor = 'rgba(255, 255, 255, 0.0)';
   this.canvas.style.pointerEvents = 'none';
-  document.body.appendChild(this.canvas);
+  this.container.appendChild(this.canvas);
 
   /**
    * @type {THREE.PerspectiveCamera}
@@ -53,43 +66,35 @@ var GLEnvironment = function(hFov) {
  * Starts running the simulation.
  **/
 GLEnvironment.prototype.run = function() {
-  window.addEventListener('resize', this.handleResize_.bind(this));
-  this.handleResize_();
-
   this.lastDraw_ = Date.now();
   this.animate_();
 };
 
 /**
- * Handles a window resize.
- * @private
+ * Handles a window resize.  Must be called from outside.
+ * @param {Number} width of container in pixels
+ * @param {Number} height of container in pixels
  */
-GLEnvironment.prototype.handleResize_ = function() {
-  var width = window.innerWidth;
-  var height = window.innerHeight;
+GLEnvironment.prototype.handleResize = function(width, height) {
+  this.canvas.style.width = width.toString() + 'px';
+  this.canvas.style.height = height.toString() + 'px';
 
   this.renderer.setSize(
     width,
     height
   );
 
-  // Scale viewport to compensate for large canvas quirks.
-  /*
-  var context = this.canvas.getContext('webgl');
-  this.renderer.setViewport(
-    0,
-    0,
-    context.drawingBufferWidth / window.devicePixelRatio,
-    context.drawingBufferHeight / window.devicePixelRatio
-  );
-  */
-
-  var hFovRad = THREE.Math.degToRad(this.hFov_);
+  var hFovRad = THREE.Math.degToRad(this.hFov);
   var vFovRad = 2 * Math.atan(Math.tan(hFovRad / 2) * (height / width));
 
   this.camera.fov = THREE.Math.radToDeg(vFovRad);
   this.camera.aspect = width / height;
   this.camera.updateProjectionMatrix();
+
+  var yawDeg = this.hFov * this.yawOffset;
+  var yawRad = THREE.Math.degToRad(yawDeg);
+  this.camera.rotation.set(0, 0, 0);
+  this.camera.rotateY(-yawRad);
 };
 
 /**

--- a/lg_sv/webapps/client/js/main.js
+++ b/lg_sv/webapps/client/js/main.js
@@ -7,6 +7,9 @@ var rosbridgeHost = getParameterByName('rosbridgeHost', String, 'localhost');
 var rosbridgePort = getParameterByName('rosbridgePort', String, '9090');
 var rosbridgeSecure = getParameterByName('rosbridgeSecure', stringToBoolean, 'false');
 window.devicePixelRatio = getParameterByName('pixelRatio', Number, 1.0);
+// scaleFactor is fixed because it changes fov non-linearly.
+// This value allows for full range of roll at 16:9.
+// See js/fov_fudge.js
 var scaleFactor = 2.04;
 var scaleMatrix = [
   [scaleFactor, 0, 0, 0],
@@ -16,7 +19,6 @@ var scaleMatrix = [
 ];
 var lastPov = null;
 
-var viewers = [];
 var initializeViewers = function() {
   console.log('initializing Street Viewers');
 

--- a/lg_sv/webapps/client/js/main.js
+++ b/lg_sv/webapps/client/js/main.js
@@ -15,10 +15,6 @@ var scaleMatrix = [
   [0, 0, 0, 1]
 ];
 var lastPov = null;
-if (showLinks) {
-  var glEnvironment;
-  var links;
-}
 
 var viewers = [];
 var initializeViewers = function() {
@@ -37,10 +33,6 @@ var initializeViewers = function() {
   ros.on('error', function() {
     setTimeout(initialize, 2000);
   });
-  if (showLinks) {
-    glEnvironment = new GLEnvironment(fieldOfView);
-    links = new Links(glEnvironment.camera, glEnvironment.scene);
-  }
 };
 
 var initializeRes = function(ros, yawOffset) {
@@ -90,6 +82,11 @@ var initializeRes = function(ros, yawOffset) {
   logo.innerText = 'Google';
   divider.appendChild(logo);
 
+  if (showLinks) {
+    var glEnvironment = new GLEnvironment(divider, fieldOfView, yawOffset);
+    var links = new Links(glEnvironment.camera, glEnvironment.scene);
+  }
+
   function handleResize() {
     var width = window.innerWidth / yawOffsets.length;
     var height = window.innerHeight;
@@ -98,6 +95,9 @@ var initializeRes = function(ros, yawOffset) {
     divider.style.width = width.toString() + 'px';
     divider.style.height = height.toString() + 'px';
     divider.style.left = left.toString() + 'px';
+    if (showLinks) {
+      glEnvironment.handleResize(width, height);
+    }
   }
   window.addEventListener('resize', handleResize, false);
   handleResize();
@@ -244,7 +244,7 @@ var initializeRes = function(ros, yawOffset) {
     wrapper.style.transform = buildTransformMatrix(scaleMatrix, rollRads);
 
     if (showLinks) {
-      links.handleView(heading, tilt, roll, fieldOfView);
+      links.handleView(povQuaternion.z, povQuaternion.x, 0, fieldOfView);
     }
   };
 

--- a/lg_sv/webapps/client/js/main.js
+++ b/lg_sv/webapps/client/js/main.js
@@ -6,8 +6,8 @@ var initialPano = getParameterByName('panoid', String, '');
 var rosbridgeHost = getParameterByName('rosbridgeHost', String, 'localhost');
 var rosbridgePort = getParameterByName('rosbridgePort', String, '9090');
 var rosbridgeSecure = getParameterByName('rosbridgeSecure', stringToBoolean, 'false');
-// Find default scaleFactor (devicePixelRatio) setting in index.html.
-var scaleFactor = getParameterByName('scaleFactor', Number, window.devicePixelRatio);
+window.devicePixelRatio = getParameterByName('pixelRatio', Number, 1.0);
+var scaleFactor = 2.04;
 var scaleMatrix = [
   [scaleFactor, 0, 0, 0],
   [0, scaleFactor, 0, 0],

--- a/lg_sv/webapps/client/js/main.js
+++ b/lg_sv/webapps/client/js/main.js
@@ -145,7 +145,7 @@ var initializeRes = function(ros, yawOffset) {
 
   var svService = new google.maps.StreetViewService();
 
-  svClient.on('pano_changed', function(panoId) {
+  function handlePanoChanged(panoId) {
     sv.setPano(panoId);
     var fovFudge = getFovFudge(fieldOfView);
     var zoomLevel = getZoomLevel(fieldOfView * scaleFactor * fovFudge);
@@ -155,6 +155,15 @@ var initializeRes = function(ros, yawOffset) {
       svClient.pubPov(lastPov);
     }
     svService.getPanorama({ pano: panoId }, handleMetadataResponse);
+  }
+  svClient.on('pano_changed', handlePanoChanged);
+  var panoService = new ROSLIB.Service({
+    ros: ros,
+    name: '/streetview/panoid_state',
+    serviceType: 'lg_sv/PanoIdState'
+  });
+  panoService.callService({}, function(resp) {
+    handlePanoChanged(resp.panoid);
   });
 
   /**


### PR DESCRIPTION
This PR adds support for multiple panels in the Street View webapp.  That means instead of using one browser per screen, we can run one browser covering all the viewports with multiple render panels.

The advantages:
* GPU interaction is consolidated.  Chrome seems to like this.
* Data requests are consolidated (Maps API doesn't even go to the cache, handles redundant requests internally).
* Zero latency sync on the same host.

Configuration should be backwards compatible with 1:1 setups.

This PR also contains a fix for #336 