### PR TITLE
Nav to device disable features

### DIFF
--- a/lg_nav_to_device/CMakeLists.txt
+++ b/lg_nav_to_device/CMakeLists.txt
@@ -18,6 +18,6 @@ catkin_install_python(PROGRAMS
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
-# if (CATKIN_ENABLE_TESTING)
-#   catkin_add_nosetests(test/test_something.py)
-# endif()
+if (CATKIN_ENABLE_TESTING)
+  catkin_add_nosetests(test/test_background_stopper.py)
+endif()

--- a/lg_nav_to_device/package.xml
+++ b/lg_nav_to_device/package.xml
@@ -16,5 +16,6 @@
   <run_depend>rospy</run_depend>
   <run_depend>python-evdev</run_depend>
   <run_depend>geometry_msgs</run_depend>
+  <run_depend>lg_common</run_depend>
 
 </package>

--- a/lg_nav_to_device/scripts/device_writer.py
+++ b/lg_nav_to_device/scripts/device_writer.py
@@ -1,22 +1,31 @@
 #!/usr/bin/env python
 
 import rospy
-from geometry_msgs.msg import Twist
-from lg_nav_to_device import DeviceWriter
-from lg_common.msg import ApplicationState
+from lg_nav_to_device import DeviceWriter, BackgroundStopper
 from lg_common.helpers import run_with_influx_exception_handler
+from lg_common.msg import ApplicationState
+from geometry_msgs.msg import Twist
+from std_msgs.msg import String
+from interactivespaces_msgs.msg import GenericMessage
 
 NODE_NAME = 'lg_nav_to_device'
+DEFAULT_DISABLE_ACTIVITIES = 'cesium,sketchfab,streetview,panovideo'
 
 
 def main():
     rospy.init_node(NODE_NAME)
 
+    disable_activities = rospy.get_param('~disable_activities', DEFAULT_DISABLE_ACTIVITIES)
+    disable_activities = [a.strip() for a in disable_activities.split(',')]
     scale = rospy.get_param('~scale', 512.0)
 
     device_writer = DeviceWriter(scale)
-    sub = rospy.Subscriber('/spacenav_wrapper/twist', Twist, device_writer.make_event)
+    rospy.Subscriber('/spacenav_wrapper/twist', Twist, device_writer.make_event)
     rospy.Subscriber('/earth/state', ApplicationState, device_writer.set_state)
+
+    background_stopper = BackgroundStopper(disable_activities, device_writer)
+    rospy.Subscriber('/director/scene', GenericMessage, background_stopper.handle_scene)
+    rospy.Subscriber('/earth/disable_nav_for_scene_slug', String, background_stopper.handle_slug)
 
     rospy.spin()
 

--- a/lg_nav_to_device/src/lg_nav_to_device/__init__.py
+++ b/lg_nav_to_device/src/lg_nav_to_device/__init__.py
@@ -1,1 +1,2 @@
 from device_writer import DeviceWriter
+from background_stopper import BackgroundStopper

--- a/lg_nav_to_device/src/lg_nav_to_device/background_stopper.py
+++ b/lg_nav_to_device/src/lg_nav_to_device/background_stopper.py
@@ -1,0 +1,52 @@
+import rospy
+import threading
+import types
+from lg_common.helpers import load_director_message, find_window_with_activity
+
+
+class BackgroundStopper:
+    def __init__(self, disable_activities, device_writer):
+        self.disable_activities = disable_activities
+        self.device_writer = device_writer
+        self._current_scene_slug = ''
+        self._disabled_scene_slug = ''
+        self._lock = threading.Lock()
+
+    def _set_writer_state(self, state):
+        self.device_writer.state = state
+
+    def _consider_scene_slugs(self):
+        if self._current_scene_slug == '':
+            return
+        elif self._disabled_scene_slug == '':
+            self._set_writer_state(True)
+        elif self._current_scene_slug == self._disabled_scene_slug:
+            self._set_writer_state(False)
+        else:
+            self._set_writer_state(True)
+
+    def handle_scene(self, msg):
+        with self._lock:
+            self._handle_scene(msg)
+
+    def _handle_scene(self, msg):
+        data = load_director_message(msg)
+
+        self._current_scene_slug = data.get('slug')
+        self._consider_scene_slugs()
+
+        for activity in self.disable_activities:
+            window = find_window_with_activity(data, activity)
+            if len(window) > 0:
+                self._set_writer_state(False)
+                return
+
+    def handle_slug(self, msg):
+        with self._lock:
+            self._handle_disable_for_scene_slug(msg)
+
+    def _handle_disable_for_scene_slug(self, msg):
+        slug_req = msg.data
+
+        self._disabled_scene_slug = slug_req
+        self._consider_scene_slugs()

--- a/lg_nav_to_device/test/test_background_stopper.py
+++ b/lg_nav_to_device/test/test_background_stopper.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+
+PKG = 'lg_nav_to_device'
+NAME = 'test_background_stopper'
+
+import sys
+import rospy
+import rostest
+import unittest
+from lg_nav_to_device import BackgroundStopper
+from std_msgs.msg import String
+from interactivespaces_msgs.msg import GenericMessage
+
+DISABLED_ACTIVITY = 'disableme'
+DISABLED_SLUG = 'disableme'
+
+
+class MockWriter:
+    def __init__(self):
+        """ Here we assume that DeviceWriter inits with state = True """
+        self.state = True
+
+
+class TestBackgroundStopper(unittest.TestCase):
+    def setUp(self):
+        self.writer = MockWriter()
+        self.stopper = BackgroundStopper([DISABLED_ACTIVITY], self.writer)
+
+    def _scene_gen(self, slug, activity):
+        director_msg = GenericMessage()
+        director_msg.type = 'json'
+        director_msg.message = """
+                {
+                      "description":"",
+                      "duration":30,
+                      "name":"lg_nav_to_device test",
+                      "resource_uri":"/director_api/scene/lg_nav_to_device-test/",
+                      "slug":"%s",
+                      "windows":[
+                        {
+                        "activity":"%s",
+                        "assets":["foo", "bar"],
+                        "height":600,
+                        "presentation_viewport":"center",
+                        "width":800,
+                        "x_coord":100,
+                        "y_coord":100
+                        }
+                        ]
+                    }
+        """ % (slug, activity)
+        return director_msg
+
+    def test_init_state(self):
+        self.assertTrue(self.writer.state)
+
+    def test_inert_scene(self):
+        scene = self._scene_gen('a_slug', 'cats')
+        self.stopper.handle_scene(scene)
+
+        self.assertTrue(self.writer.state)
+
+    def test_disabled_activity(self):
+        scene = self._scene_gen('a_slug', DISABLED_ACTIVITY)
+        self.stopper.handle_scene(scene)
+
+        self.assertFalse(self.writer.state)
+
+    def test_disabled_slug_first(self):
+        slug_msg = String(DISABLED_SLUG)
+        self.stopper.handle_slug(slug_msg)
+
+        self.test_init_state()
+
+        scene = self._scene_gen(DISABLED_SLUG, 'cats')
+        self.stopper.handle_scene(scene)
+
+        self.assertFalse(self.writer.state)
+
+    def test_disabled_slug_second(self):
+        scene = self._scene_gen(DISABLED_SLUG, 'cats')
+        self.stopper.handle_scene(scene)
+
+        self.assertTrue(self.writer.state)
+
+        slug_msg = String(DISABLED_SLUG)
+        self.stopper.handle_slug(slug_msg)
+
+        self.assertFalse(self.writer.state)
+
+    def test_inert_slug_first(self):
+        slug_msg = String('fubs')
+        self.stopper.handle_slug(slug_msg)
+
+        self.test_init_state()
+
+        scene = self._scene_gen('bufs', 'cats')
+        self.stopper.handle_scene(scene)
+
+        self.assertTrue(self.writer.state)
+
+    def test_inert_slug_second(self):
+        scene = self._scene_gen('fubs', 'cats')
+        self.stopper.handle_scene(scene)
+
+        self.assertTrue(self.writer.state)
+
+        slug_msg = String('bufs')
+        self.stopper.handle_slug(slug_msg)
+
+        self.assertTrue(self.writer.state)
+
+    def test_next_scene(self):
+        slug_msg = String(DISABLED_SLUG)
+        self.stopper.handle_slug(slug_msg)
+
+        self.test_init_state()
+
+        scene = self._scene_gen(DISABLED_SLUG, 'cats')
+        self.stopper.handle_scene(scene)
+
+        self.assertFalse(self.writer.state)
+
+        scene = self._scene_gen('fubs', 'cats')
+        self.stopper.handle_scene(scene)
+
+        self.assertTrue(self.writer.state)
+
+
+if __name__ == '__main__':
+    rostest.rosrun(PKG, NAME, TestBackgroundStopper, sys.argv)
+
+# vim: tabstop=8 expandtab shiftwidth=4 softtabstop=4

--- a/lg_sv/launch/video.launch
+++ b/lg_sv/launch/video.launch
@@ -7,6 +7,7 @@
 
   <param name="/viewport/left" value="800x600+0+0" />
   <param name="/viewport/right" value="800x600+800+0" />
+  <node name="uscs_service" pkg="lg_common" type="uscs_service.py" />
   <node name="webserver" pkg="lg_common" type="dev_webserver.py" />
   <node name="rosbridge" pkg="rosbridge_server" type="rosbridge_websocket" />
   <node name="ws_distributor" pkg="lg_sv" type="ws_distributor">

--- a/lg_sv/webapps/panovideosync/index.html
+++ b/lg_sv/webapps/panovideosync/index.html
@@ -72,6 +72,33 @@ if (videoUrl) {
 }
 
 sync.animate();
+
+// Disable SpaceNav in the background for this scene.
+let disableSlugTopic = new ROSLIB.Topic({
+  ros: ros,
+  name: '/earth/disable_nav_for_scene_slug',
+  messageType: 'std_msgs/String'
+});
+disableSlugTopic.advertise();
+
+let sceneService = new ROSLIB.Service({
+  ros : ros,
+  name : '/uscs/message',
+  serviceType : 'lg_common/USCSService'
+});
+let sceneRequest = new ROSLIB.ServiceRequest({});
+sceneService.callService(sceneRequest, (result) => {
+  console.log(result);
+  if (result.type !== 'json') {
+    console.warn('Non-JSON response from USCS service, can not disable Earth Nav');
+    return;
+  }
+  let sceneData = JSON.parse(result.message);
+  let disableSlugMsg = new ROSLIB.Message({
+    data: sceneData['slug']
+  });
+  disableSlugTopic.publish(disableSlugMsg);
+});
 </script>
 
 </body>


### PR DESCRIPTION
Lets us disable Earth navigation in the background in a couple of ways:

* Blacklisted activity types in director scenes.  Ideal for "first class" and full screen activities e.g. Street View.

* Blacklisted scene slugs.  This allows us to disable Nav in a particular scene from an ad hoc webapp (or anywhere).  See https://github.com/EndPointCorp/lg_ros_nodes/commit/70dc3d95a6ef5d980e0e760912c782215d0fc3f0