### PR TITLE
allow insecure content

### DIFF
--- a/lg_common/src/lg_common/managed_browser.py
+++ b/lg_common/src/lg_common/managed_browser.py
@@ -23,6 +23,7 @@ DEFAULT_ARGS = [
     '--touch-events=enabled',
     '--disable-pinch',
     '--overscroll-history-navigation=0',
+    '--allow-running-insecure-content',
     '--disable-touch-editing',
     '--v=1',
     '--enable-webgl',


### PR DESCRIPTION
This will help us show pages where our extension is using either http
or https, and the page its on is using the opposite.