### PR TITLE
Reset touch receiver matrix on fresh input

### DIFF
--- a/lg_mirror/include/lg_mirror/ros_event_relay.h
+++ b/lg_mirror/include/lg_mirror/ros_event_relay.h
@@ -7,6 +7,7 @@
 #include "uinput_device.h"
 #include "viewport_mapper.h"
 #include "lg_common/StringArray.h"
+#include "lg_mirror/EvdevEvents.h"
 
 class RosEventRelay {
   public:
@@ -19,6 +20,8 @@ class RosEventRelay {
       bool auto_zero
     );
     void HandleRouterMessage(const lg_common::StringArrayPtr& msg);
+    void HandleEventMessage(const lg_mirror::EvdevEvents::Ptr& msg);
+    void ResetIdleRemap(const ros::TimerEvent& tev);
 
   private:
     void OpenRoute_();
@@ -26,13 +29,15 @@ class RosEventRelay {
     void ZeroDevice_();
 
     bool routing_;
-    ros::Subscriber s_;
+    ros::Subscriber router_sub_;
     ros::NodeHandle n_;
     std::string viewport_name_;
     std::string events_topic_;
     UinputDevice device_;
     ViewportMapper mapper_;
     bool auto_zero_;
+    bool should_idle_remap_;
+    ros::Timer idle_remap_timer_;
 };
 
 #endif // _ROS_EVENT_RELAY_H_


### PR DESCRIPTION
Workaround for Xorg mysteriously resetting the coordinate transformation matrix to identity.