### PR TITLE
Fix some service waiting and other issues

### DIFF
--- a/lg_common/scripts/adhoc_browser.py
+++ b/lg_common/scripts/adhoc_browser.py
@@ -79,8 +79,6 @@ def main():
     director_ready_sub = rospy.Subscriber('/director/ready', Ready, adhocbrowser_pool.unhide_browsers)
     actors.append(director_ready_sub)
 
-    rospy.wait_for_service('/readiness_node/ready', 15)
-    rospy.wait_for_service('/lg_offliner/status', 15)
     wait_for_pub_sub_connections(actors)
 
     handle_initial_state(adhocbrowser_director_bridge.translate_director)

--- a/lg_common/src/lg_common/helpers.py
+++ b/lg_common/src/lg_common/helpers.py
@@ -897,7 +897,17 @@ def handle_initial_state(call_back):
 
     initial_state_service = rospy.ServiceProxy('/initial_state', InitialUSCS)
 
-    state = initial_state_service.call()
+    tries = 0
+    state = None
+    while not state and not rospy.is_shutdown():
+        try:
+            tries += 1
+            state = initial_state_service.call()
+        except rospy.service.ServiceException:
+            if tries > 10:
+                raise
+            rospy.sleep(1.0)
+
     if state and state != InitialUSCSResponse():
         rospy.loginfo('got initial state: %s for callback %s' % (state.message, call_back))
         call_back(state)

--- a/lg_common/src/lg_common/helpers.py
+++ b/lg_common/src/lg_common/helpers.py
@@ -895,7 +895,7 @@ def handle_initial_state(call_back):
     """
     from lg_msg_defs.srv import InitialUSCS, InitialUSCSResponse
 
-    initial_state_service = rospy.ServiceProxy('/initial_state', InitialUSCS)
+    initial_state_service = rospy.ServiceProxy('/initial_state', InitialUSCS, persistent=False)
 
     tries = 0
     state = None

--- a/lg_common/src/lg_common/helpers.py
+++ b/lg_common/src/lg_common/helpers.py
@@ -893,13 +893,6 @@ def handle_initial_state(call_back):
     Query for initial state from state service and run
     the call back with that state if available
     """
-    # commenting out for now
-    try:
-        rospy.wait_for_service('/initial_state', 15)
-    except Exception:
-        rospy.logerr("This system does not support initial state setting")
-        return
-
     from lg_msg_defs.srv import InitialUSCS, InitialUSCSResponse
 
     initial_state_service = rospy.ServiceProxy('/initial_state', InitialUSCS)

--- a/lg_earth/scripts/add_kml.py
+++ b/lg_earth/scripts/add_kml.py
@@ -170,7 +170,7 @@ def main():
     director_pub = rospy.Publisher('/director/scene', GenericMessage, queue_size=10)
     added_kml_pub = rospy.Publisher('/lg_earth/added_kml', StringArray, latch=True, queue_size=1)
 
-    uscs_service = rospy.ServiceProxy('/uscs/message', USCSMessage)
+    uscs_service = rospy.ServiceProxy('/uscs/message', USCSMessage, persistent=False)
 
     hostname = rospy.get_param('~hostname', 'localhost')
     port = rospy.get_param('~port', 18111)

--- a/lg_earth/scripts/kmlsync.py
+++ b/lg_earth/scripts/kmlsync.py
@@ -45,9 +45,6 @@ def main():
     ], debug=True)
 
     global_dependency_timeout = int(rospy.get_param('~global_dependency_timeout', 15))
-    rospy.wait_for_service('/kmlsync/state', global_dependency_timeout)
-    rospy.wait_for_service('/kmlsync/playtour_query', global_dependency_timeout)
-    rospy.wait_for_service('/kmlsync/planet_query', global_dependency_timeout)
 
     director_scene_topic = rospy.get_param('~director_topic', '/director/scene')
     rospy.Subscriber(director_scene_topic, GenericMessage, KmlUpdateHandler.get_scene_msg)

--- a/lg_earth/src/lg_earth/kmlalive.py
+++ b/lg_earth/src/lg_earth/kmlalive.py
@@ -16,43 +16,34 @@ class KmlAlive:
         self.worked = False
 
     def keep_alive(self, *args, **kwargs):
-        try:
-            self._keep_alive(args, kwargs)
-        except Exception as e:
-            rospy.logerr("exception was {} {} {}".format(e, traceback.format_exc(), sys.exc_info()[0]))
-            rospy.sleep(1)
-            self.keep_alive(args, kwargs)
-
-    def _keep_alive(self, *args, **kwargs):
         rospy.logerr("XXX in first keep_alive")
         loop_timeout = 1
         counter = 0
         rospy.sleep(1)
-        with open('/dev/null', 'w') as dev_null:
-            while not rospy.is_shutdown():
-                try:
-                    pid = self.earth_proc.proc.watcher.proc.pid
-                except AttributeError as e:
-                    counter = 0
-                    rospy.logwarn("Earth proc doesn't exist {}".format(e))
-                    rospy.sleep(loop_timeout)
-                    continue
-                cmd = "lsof -Pn -p {} -a -i @127.0.0.1:8765".format(pid).split(' ')
-                ret_value = subprocess.call(
-                    cmd,
-                    stdout=dev_null,
-                    stderr=dev_null,
-                    close_fds=True
-                )
-                if ret_value == 0:
-                    self.worked = True
-                    counter = 0
-                else:
-                    counter += 1
-                    rospy.logerr("XXX found non zero value for {} counter at {}".format(pid, counter))
-                    if (counter > self.timeout_period and self.worked) or counter > self.initial_timeout:
-                        rospy.logerr("XXX RELAUNCHING worked: {}  counter: {}".format(self.worked, counter))
-                        self.earth_proc.handle_soft_relaunch()
-                        counter = 0
-                        self.worked = False
+        while not rospy.is_shutdown():
+            try:
+                pid = self.earth_proc.proc.watcher.proc.pid
+            except AttributeError as e:
+                counter = 0
+                rospy.logwarn("Earth proc doesn't exist {}".format(e))
                 rospy.sleep(loop_timeout)
+                continue
+            cmd = "lsof -Pn -p {} -a -i @127.0.0.1:8765".format(pid).split(' ')
+            ret_value = subprocess.call(
+                cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                close_fds=True
+            )
+            if ret_value == 0:
+                self.worked = True
+                counter = 0
+            else:
+                counter += 1
+                rospy.logerr("XXX found non zero value for {} counter at {}".format(pid, counter))
+                if (counter > self.timeout_period and self.worked) or counter > self.initial_timeout:
+                    rospy.logerr("XXX RELAUNCHING worked: {}  counter: {}".format(self.worked, counter))
+                    self.earth_proc.handle_soft_relaunch()
+                    counter = 0
+                    self.worked = False
+            rospy.sleep(loop_timeout)

--- a/lg_earth/src/lg_earth/kmlalive.py
+++ b/lg_earth/src/lg_earth/kmlalive.py
@@ -37,11 +37,6 @@ class KmlAlive:
                     rospy.logwarn("Earth proc doesn't exist {}".format(e))
                     rospy.sleep(loop_timeout)
                     continue
-                try:
-                    rospy.wait_for_service('/kmlsync/state', 5)
-                except rospy.ROSException:
-                    rospy.logerr("no kml sync state found")
-                    continue
                 cmd = "lsof -Pn -p {} -a -i @127.0.0.1:8765".format(pid).split(' ')
                 ret_value = subprocess.call(
                     cmd,

--- a/lg_lock/scripts/service.py
+++ b/lg_lock/scripts/service.py
@@ -26,7 +26,7 @@ def init():
         print("No or blank password provided, exiting...")
         return
 
-    suppressProxy = rospy.ServiceProxy('/spacenav_wrapper/suppress', SetBool)
+    suppressProxy = rospy.ServiceProxy('/spacenav_wrapper/suppress', SetBool, persistent=False)
 
     def onChange(state):
         if suppress_spacenav:

--- a/lg_pointer/scripts/mouse_to_pointer.py
+++ b/lg_pointer/scripts/mouse_to_pointer.py
@@ -81,7 +81,7 @@ def main():
                                  StringArray, queue_size=10)
     feedback_pub = rospy.Publisher('/joy/set_feedback',
                                    JoyFeedbackArray, queue_size=10)
-    imu_calibrate = rospy.ServiceProxy('/imu/calibrate', Empty, persistent=True)
+    imu_calibrate = rospy.ServiceProxy('/imu/calibrate', Empty, persistent=False)
     mouse_timeout = int(rospy.get_param('~mouse_timeout', 10))
     sleep_time = 0.01  # ooo magic, pretty
 

--- a/lg_pointer/scripts/wiimote_to_pointer.py
+++ b/lg_pointer/scripts/wiimote_to_pointer.py
@@ -190,7 +190,7 @@ def main():
                                  StringArray, queue_size=10)
     feedback_pub = rospy.Publisher('/joy/set_feedback',
                                    JoyFeedbackArray, queue_size=10)
-    imu_calibrate = rospy.ServiceProxy('/imu/calibrate', Empty, persistent=True)
+    imu_calibrate = rospy.ServiceProxy('/imu/calibrate', Empty, persistent=False)
 
     mvp = MegaViewport(viewports, arc_width)
 

--- a/lg_volume_control/scripts/volume_control_slave.py
+++ b/lg_volume_control/scripts/volume_control_slave.py
@@ -25,7 +25,7 @@ def main():
 
 def grab_master_volume():
     try:
-        master_node_volume = rospy.ServiceProxy('volume', Volume)
+        master_node_volume = rospy.ServiceProxy('volume', Volume, persistent=False)
         rospy.sleep(1)
         volume = master_node_volume()
         rospy.logdebug("got volume {} from master".format(volume))

--- a/state_proxy/scripts/state_setter.py
+++ b/state_proxy/scripts/state_setter.py
@@ -162,7 +162,7 @@ def main():
     display_pub = rospy.Publisher('/display/switch', String, queue_size=10)
     kiosk_pub = rospy.Publisher('/kiosk/switch', String, queue_size=10)
 
-    last_uscs_service = rospy.ServiceProxy('/uscs/message', USCSMessage)
+    last_uscs_service = rospy.ServiceProxy('/uscs/message', USCSMessage, persistent=False)
 
     state_setter = StateSetter(state_pub, display_pub, kiosk_pub, runway_pub, last_uscs_service)
 

--- a/state_proxy/scripts/state_setter.py
+++ b/state_proxy/scripts/state_setter.py
@@ -162,7 +162,6 @@ def main():
     display_pub = rospy.Publisher('/display/switch', String, queue_size=10)
     kiosk_pub = rospy.Publisher('/kiosk/switch', String, queue_size=10)
 
-    rospy.wait_for_service('/uscs/message', 10)
     last_uscs_service = rospy.ServiceProxy('/uscs/message', USCSMessage)
 
     state_setter = StateSetter(state_pub, display_pub, kiosk_pub, runway_pub, last_uscs_service)

--- a/state_proxy/scripts/state_tracker.py
+++ b/state_proxy/scripts/state_tracker.py
@@ -134,11 +134,6 @@ def main():
     update_rfid_topic = rospy.get_param('~update_rfid_topic', '/rfid/uscs/update')
     tactile_flag = rospy.get_param('~tactile_flag', '')
 
-    # wait for service or kill node
-    rospy.wait_for_service('/uscs/message', 10)
-    rospy.wait_for_service('/browser_service/wall', 10)
-    rospy.wait_for_service('/browser_service/kiosk', 10)
-
     last_uscs_service = rospy.ServiceProxy('/uscs/message', USCSMessage)
     kiosk_url_service = rospy.ServiceProxy('/browser_service/kiosk', BrowserPool)
     display_url_service = rospy.ServiceProxy('/browser_service/wall', BrowserPool)

--- a/state_proxy/scripts/state_tracker.py
+++ b/state_proxy/scripts/state_tracker.py
@@ -134,9 +134,9 @@ def main():
     update_rfid_topic = rospy.get_param('~update_rfid_topic', '/rfid/uscs/update')
     tactile_flag = rospy.get_param('~tactile_flag', '')
 
-    last_uscs_service = rospy.ServiceProxy('/uscs/message', USCSMessage)
-    kiosk_url_service = rospy.ServiceProxy('/browser_service/kiosk', BrowserPool)
-    display_url_service = rospy.ServiceProxy('/browser_service/wall', BrowserPool)
+    last_uscs_service = rospy.ServiceProxy('/uscs/message', USCSMessage, persistent=False)
+    kiosk_url_service = rospy.ServiceProxy('/browser_service/kiosk', BrowserPool, persistent=False)
+    display_url_service = rospy.ServiceProxy('/browser_service/wall', BrowserPool, persistent=False)
 
     current_state = rospy.Publisher(current_state_topic, String, queue_size=10)
     update_rfid_pub = rospy.Publisher(update_rfid_topic, String, queue_size=10)


### PR DESCRIPTION
`rospy.wait_for_service` is known to be unreliable when running in Python 3, so don't use it.  Where needed, do an unwrapped retry.

Use explicitly non-persistent `ServiceProxy` everywhere because persistent is known to be unreliable.

Also fix a scary issue with kmlalive recursing upon error.