### PR TITLE
Add lg_navlib package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -137,6 +137,7 @@ COPY lg_mirror/package.xml ${PROJECT_ROOT}/lg_mirror/package.xml
 COPY lg_msg_defs/package.xml ${PROJECT_ROOT}/lg_msg_defs/package.xml
 COPY lg_nav_to_device/package.xml ${PROJECT_ROOT}/lg_nav_to_device/package.xml
 COPY lg_lock/package.xml ${PROJECT_ROOT}/lg_lock/package.xml
+COPY lg_navlib/package.xml ${PROJECT_ROOT}/lg_navlib/package.xml
 COPY lg_offliner/package.xml ${PROJECT_ROOT}/lg_offliner/package.xml
 COPY lg_panovideo/package.xml ${PROJECT_ROOT}/lg_panovideo/package.xml
 COPY lg_pointer/package.xml ${PROJECT_ROOT}/lg_pointer/package.xml

--- a/lg_navlib/CMakeLists.txt
+++ b/lg_navlib/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
 )
 
-catkin_python_setup()
+#catkin_python_setup()
 
 catkin_package()
 

--- a/lg_navlib/CMakeLists.txt
+++ b/lg_navlib/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(lg_navlib)
+
+find_package(catkin REQUIRED COMPONENTS
+  lg_msg_defs
+  message_runtime
+  rospy
+  std_msgs
+)
+
+catkin_python_setup()
+
+catkin_package()
+
+include_directories(
+  ${catkin_INCLUDE_DIRS}
+)
+
+catkin_install_python(PROGRAMS
+  scripts/nav_mode.py
+  DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+if (CATKIN_ENABLE_TESTING)
+  set(PYTHON_EXECUTABLE /usr/bin/python3)
+  find_package(rostest REQUIRED)
+  add_rostest(test/test_nav_mode.test)
+endif()

--- a/lg_navlib/package.xml
+++ b/lg_navlib/package.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>lg_navlib</name>
+  <version>3.2.9</version>
+  <description>Backend for lg_navlib user navigation library.</description>
+
+  <maintainer email="lg@endpoint.com">End Point Liquid Galaxy Team</maintainer>
+  <author email="matt@endpoint.com">Matt Vollrath</author>
+
+  <license>TODO</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>lg_msg_defs</build_depend>
+  <build_depend>message_runtime</build_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <exec_depend>lg_msg_defs</exec_depend>
+  <exec_depend>message_runtime</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <test_depend>rostest</test_depend>
+</package>

--- a/lg_navlib/scripts/nav_mode.py
+++ b/lg_navlib/scripts/nav_mode.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+import rospy
+from lg_msg_defs.msg import ApplicationState
+from std_msgs.msg import String
+
+
+class NavMode:
+    def __init__(self, mode_pub, default_mode):
+        self.mode_pub = mode_pub
+        self.mode = default_mode
+        self.publish_mode()
+
+    def handle_state(self, msg, mode):
+        if msg.state != ApplicationState.VISIBLE:
+            return
+        self.mode = mode
+        self.publish_mode()
+
+    def publish_mode(self):
+        self.mode_pub.publish(String(data=self.mode))
+
+
+if __name__ == '__main__':
+    rospy.init_node('nav_mode')
+
+    default_mode = rospy.get_param('~default_mode')
+
+    mode_pub = rospy.Publisher('/lg_navlib/nav_mode', String, latch=True, queue_size=1)
+    nav_mode = NavMode(mode_pub, default_mode)
+
+    modes = rospy.get_param(f'~modes')
+    for mode, topics in modes.items():
+        topics = [t.strip() for t in topics.split(',')]
+        for topic in topics:
+            rospy.Subscriber(topic, ApplicationState, nav_mode.handle_state, mode)
+
+    rospy.spin()

--- a/lg_navlib/setup.py
+++ b/lg_navlib/setup.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python3
+
+from distutils.core import setup
+from catkin_pkg.python_setup import generate_distutils_setup
+
+d = generate_distutils_setup(
+    packages=['lg_navlib'],
+    package_dir={'': 'src'},
+)
+
+setup(**d)

--- a/lg_navlib/test/test_nav_mode.py
+++ b/lg_navlib/test/test_nav_mode.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+PKG = 'lg_navlib'
+NAME = 'test_nav_mode'
+
+import rospy
+import unittest
+from lg_msg_defs.msg import ApplicationState
+from std_msgs.msg import String
+
+DELAY = 0.25  # Allow this many seconds for pubsub connections and messaging.
+
+# We expect these states to cause a mode publication.
+ACTIVE_STATES = [
+    ApplicationState.VISIBLE,
+]
+# We expect these states to not cause a mode publication.
+INERT_STATES = [
+    ApplicationState.STOPPED,
+    ApplicationState.SUSPENDED,
+    ApplicationState.HIDDEN,
+    ApplicationState.STARTED,
+]
+
+
+class TestNavMode(unittest.TestCase):
+    def setUp(self):
+        self.mode_msgs = []
+        self.mode_sub = rospy.Subscriber(
+            '/lg_navlib/nav_mode',
+            String,
+            self.mode_msgs.append,
+        )
+        rospy.sleep(DELAY)
+
+    def tearDown(self):
+        self.mode_sub.unregister()
+
+    def _expect_mode(self, mode=None):
+        self.assertEqual(len(self.mode_msgs), 1)
+        if mode:
+            self.assertEqual(self.mode_msgs[0].data, mode)
+        del self.mode_msgs[:]
+
+    def test_01_default_mode(self):
+        default_mode = rospy.get_param('/nav_mode/default_mode')
+        self._expect_mode(default_mode)  # Latching topic, we should already have a message.
+
+    def test_02_modes(self):
+        self._expect_mode()  # Discard latched mode.
+
+        modes = rospy.get_param('/nav_mode/modes')
+        for mode, topics in modes.items():
+            topics = [t.strip() for t in topics.split(',')]
+            for topic in topics:
+                pub = rospy.Publisher(topic, ApplicationState, queue_size=1)
+                rospy.sleep(DELAY)
+                for state in ACTIVE_STATES:
+                    pub.publish(ApplicationState(state=state))
+                    rospy.sleep(DELAY)
+                    self._expect_mode(mode)
+                for state in INERT_STATES:
+                    pub.publish(ApplicationState(state=state))
+                    rospy.sleep(DELAY)
+                    self.assertEqual(len(self.mode_msgs), 0)
+
+
+if __name__ == '__main__':
+    import rostest
+    rospy.init_node(NAME)
+    rostest.rosrun(PKG, NAME, TestNavMode)

--- a/lg_navlib/test/test_nav_mode.test
+++ b/lg_navlib/test/test_nav_mode.test
@@ -1,0 +1,8 @@
+<launch>
+  <node name="nav_mode" pkg="lg_navlib" type="nav_mode.py">
+    <param name="default_mode" value="none" />
+    <param name="modes/eyelevel" value="  /foo/bar, /baz/bang" />
+    <param name="modes/globe" value="/a/globe,b/globe  " />
+  </node>
+  <test test-name="test_nav_mode" pkg="lg_navlib" type="test_nav_mode.py" />
+</launch>

--- a/liquidgalaxy/package.xml
+++ b/liquidgalaxy/package.xml
@@ -22,6 +22,7 @@
   <run_depend>lg_mirror</run_depend>
   <run_depend>lg_nav_to_device</run_depend>
   <run_depend>lg_lock</run_depend>
+  <run_depend>lg_navlib</run_depend>
   <run_depend>lg_offliner</run_depend>
   <run_depend>lg_panovideo</run_depend>
   <run_depend>lg_proximity</run_depend>

--- a/pack-debs
+++ b/pack-debs
@@ -47,6 +47,7 @@ $BUILD $SRCDIR/lg_media
 $BUILD $SRCDIR/lg_mirror
 $BUILD $SRCDIR/lg_nav_to_device
 $BUILD $SRCDIR/lg_lock
+$BUILD $SRCDIR/lg_navlib
 $BUILD $SRCDIR/lg_offliner
 $BUILD $SRCDIR/lg_panovideo
 $BUILD $SRCDIR/lg_proximity


### PR DESCRIPTION
Backend support for lg_navlib user interface library.

The nav_mode.py script listens for application state changes
and publishes configured navigation mode when applications
become visible.

The intention is to help user interfaces send appropriate axis
translations for the panoramic content.

For example, the SpaceNav axes are different between:
* Globe apps like Cesium and Earth
* Eye-level apps like Street View and panoramic image/video

When implementing a generic multi-touch to SpaceNav interface,
we need to know which axis mapping to use.  Pan may be
translation in one context and rotation in another.