### PR TITLE
initial zoom integration

### DIFF
--- a/lg_sv/webapps/client/js/main.js
+++ b/lg_sv/webapps/client/js/main.js
@@ -144,13 +144,17 @@ var initializeRes = function(ros, yawOffset) {
 
   var svService = new google.maps.StreetViewService();
 
-  function handlePanoChanged(panoId) {
+  function handlePanoChanged({panoId, zoom=false}) {
     sv.setPano(panoId);
-    if (shouldTilt) {
-      var fovFudge = getFovFudge(fieldOfView);
-      var zoomLevel = getZoomLevel(fieldOfView * scaleFactor * fovFudge);
+    if (zoom) {
+      zoomLevel = zoom
     } else {
-      var zoomLevel = getZoomLevel(fieldOfView);
+      if (shouldTilt) {
+        var fovFudge = getFovFudge(fieldOfView);
+        var zoomLevel = getZoomLevel(fieldOfView * scaleFactor * fovFudge);
+      } else {
+        var zoomLevel = getZoomLevel(fieldOfView);
+      }
     }
     sv.setZoom(zoomLevel);
     if (lastPov) {
@@ -185,13 +189,15 @@ var initializeRes = function(ros, yawOffset) {
       pov.z = sv_window['activity_config']['heading'];
     if (sv_window['activity_config']['tilt'])
       pov.x = sv_window['activity_config']['tilt'];
+    
+    var zoom = sv_window['activity_config']?.['zoom'] || false;
 
 
     if (panoid[0] == '-' && panoid.search("%2F") > -1)
       panoid = "F:" + panoid;
 
     console.log("Emitting " + panoid + " with pov " + pov);
-    svClient.emit('pano_changed', panoid);
+    svClient.emit('pano_changed', {'panoid': panoid, 'zoom': zoom});
     svClient.emit('pov_changed', pov);
   }
   svClient.on('director_message', handleDirectorMessage);


### PR DESCRIPTION
small change, we shall see if the zoom needs to be augmented for tilt enabled systems.  Basic idea is FE already grabs zoom from the SV urls (if that's how they are being added) and can easily send it along as an assetAttribute.  assetAttributes get picked up by the director api and converted to elements in the activity_config. All we are doing now is taking them (if they exist) instead of using the maths involving FOV. 