### PR TITLE
Fix gstreamer player close on finish

### DIFF
--- a/lg_media/src/lg_media/gstreamer_pool.py
+++ b/lg_media/src/lg_media/gstreamer_pool.py
@@ -61,6 +61,8 @@ class ManagedGstreamer(ManagedApplication):
             cmd.extend(self.extra_args.split())
 
         cmd.append("-d")  # Disable hardware decoding -- for compatibility
+        if self.respawn is False:
+            cmd.append("-c")  # close on finish
         cmd.extend(["-n", str(self.slug)])
         cmd.extend(["-u", self.url])
         if self.window:


### PR DESCRIPTION
* Add `-c` arg to `gst_video_sync` to close on media EOS
* Update player sync command based on lg_media message onFinish

Fixes #451 