### PR TITLE
Remove hardcoded default user agent from touchscreen.py and static_browser.py

### DIFF
--- a/lg_common/scripts/static_browser.py
+++ b/lg_common/scripts/static_browser.py
@@ -22,11 +22,7 @@ def main():
     scale_factor = rospy.get_param('~force_device_scale_factor', 1)
     extra_logging = rospy.get_param('~extra_logging', False)
     debug_port = rospy.get_param('~debug_port', None)
-    user_agent = rospy.get_param(
-        '~user_agent', 'Mozilla/5.0(iPad; U; CPU iPhone OS 3_2 like Mac OS X; '
-        'en-us AppleWebKit/531.21.10 (KHTML, like Gecko) ' +
-        'Version/4.0.4 Mobile/7B314 Safari/531.21.10'
-    )
+    user_agent = rospy.get_param('~user_agent', None)
     state = rospy.get_param('~state', ApplicationState.VISIBLE)
     extensions = rospy.get_param('~extensions', [])
     kiosk = rospy.get_param('~kiosk', True)

--- a/lg_common/scripts/touchscreen.py
+++ b/lg_common/scripts/touchscreen.py
@@ -67,11 +67,7 @@ def main():
 
     scale_factor = rospy.get_param('~force_device_scale_factor', 1)
     debug_port = rospy.get_param('~debug_port', None)
-    user_agent = rospy.get_param(
-        '~user_agent', 'Mozilla/5.0(iPad; U; CPU iPhone OS 3_2 like Mac OS X; '
-        'en-us AppleWebKit/531.21.10 (KHTML, like Gecko) ' +
-        'Version/4.0.4 Mobile/7B314 Safari/531.21.10'
-    )
+    user_agent = rospy.get_param('~user_agent', None)
     log_level = rospy.get_param('/logging/level', 0)
 
     browser = ManagedBrowser(


### PR DESCRIPTION
Small change to remove the hardcoded user_agents. @constantegonzalez found that it could be reported to internal security as an old browser, in some situations. 

Made this a PR b/c not sure how important it is in the first place to change. But secondly, looks like lg_screenshot looks for a default user agent, in which case it might be better to simply update the user agent to something a bit more recent, even if it eventually gets "old" again.

No seeming issues running on the system when manually removing the user agent and running the touchscreen browser. 