### PR TITLE
Image viewer opts

### DIFF
--- a/lg_media/scripts/image_viewer.py
+++ b/lg_media/scripts/image_viewer.py
@@ -82,8 +82,6 @@ class ImageViewer():
                     y=window['y_coord']
                 )
                 image.transparent = window.get('activity_config', {}).get('transparent', False)
-                graphic_opts[(image.url, image.geometry.x, image.geometry.y)] = {}
-                graphic_opts[(image.url, image.geometry.x, image.geometry.y)]['upscale'] = window.get('activity_config', {}).get('upscale', False)
 
                 image.viewport = window['presentation_viewport']
                 if image.viewport not in self.viewports:
@@ -93,6 +91,9 @@ class ImageViewer():
                 image.geometry.y = image.geometry.y + offset_geometry.y
                 image.uuid = str(uuid.uuid4())
                 windows_to_add.images.append(image)
+                
+                graphic_opts[(image.url, image.geometry.x, image.geometry.y)] = {}
+                graphic_opts[(image.url, image.geometry.x, image.geometry.y)]['no_upscale'] = window.get('activity_config', {}).get('no_upscale', False)
         logger.error(f"ZZZ {windows_to_add}")
         self.handle_image_views(windows_to_add)
 
@@ -176,9 +177,9 @@ class ImageViewer():
         r = requests.get(image.url)
         with open(image_path, 'wb') as f:
             f.write(r.content)
-        opts = ''
-        if graphic_opts[(image.url, image.geometry.x, image.geometry.y)]['upscale']:
-            opts += '-t'
+        opts = '-t'
+        if graphic_opts[(image.url, image.geometry.x, image.geometry.y)]['no_upscale']:
+            opts = ''
 
         command = '/usr/bin/pqiv -c -i {} --scale-mode-screen-fraction=1.0 -T {} -P {},{} {}'.format(
             opts,

--- a/lg_media/scripts/image_viewer.py
+++ b/lg_media/scripts/image_viewer.py
@@ -178,7 +178,7 @@ class ImageViewer():
         with open(image_path, 'wb') as f:
             f.write(r.content)
         opts = '-t'
-        if graphic_opts[(image.url, image.geometry.x, image.geometry.y)]['no_upscale']:
+        if graphic_opts.get((image.url, image.geometry.x, image.geometry.y), {}).get('no_upscale', False):
             opts = ''
 
         command = '/usr/bin/pqiv -c -i {} --scale-mode-screen-fraction=1.0 -T {} -P {},{} {}'.format(

--- a/lg_media/scripts/image_viewer.py
+++ b/lg_media/scripts/image_viewer.py
@@ -82,7 +82,8 @@ class ImageViewer():
                     y=window['y_coord']
                 )
                 image.transparent = window.get('activity_config', {}).get('transparent', False)
-                graphic_opts[(image.url, image.geometry.x, image.geometry.y)] = window.get('activity_config', {}).get('graphic_opts', '')
+                graphic_opts[(image.url, image.geometry.x, image.geometry.y)] = {}
+                graphic_opts[(image.url, image.geometry.x, image.geometry.y)]['upscale'] = window.get('activity_config', {}).get('upscale', False)
 
                 image.viewport = window['presentation_viewport']
                 if image.viewport not in self.viewports:
@@ -175,8 +176,12 @@ class ImageViewer():
         r = requests.get(image.url)
         with open(image_path, 'wb') as f:
             f.write(r.content)
+        opts = ''
+        if graphic_opts[(image.url, image.geometry.x, image.geometry.y)]['upscale']:
+            opts += '-t'
+
         command = '/usr/bin/pqiv -c -i {} --scale-mode-screen-fraction=1.0 -T {} -P {},{} {}'.format(
-            graphic_opts[(image.url, image.geometry.x, image.geometry.y)],
+            opts,
             image.uuid,
             image.geometry.x,
             image.geometry.y,

--- a/lg_media/scripts/image_viewer.py
+++ b/lg_media/scripts/image_viewer.py
@@ -100,23 +100,23 @@ class ImageViewer():
 
     def _handle_image_views(self, msg):
         global matched_images_dict
-        logger.error("handling image views")
+        logger.debug("handling image views")
         new_current_images = {}
         images_to_remove = list(self.current_images.values())
         images_to_add = []
         images_to_remove_delayed = []
         matched_images_dict = {}
         for image in msg.images:
-            # logger.error('CURRENT IMAGES: {}\n\n'.format(self.current_images))
+            logger.debug('CURRENT IMAGES: {}\n\n'.format(self.current_images))
             duplicate_image = self.is_in_current_images(self.current_images, image)
             if duplicate_image:
-                # logger.error('Keeping image: {}\n\n'.format(image))
+                logger.info('Keeping image: {}\n\n'.format(image))
                 images_to_remove.remove(duplicate_image)
                 new_current_images[make_key_from_image(image)] = duplicate_image
                 continue
             current_coordinate_image = self.is_current_coordinates(self.current_images, image)
             if current_coordinate_image:
-                logger.error("image matched, waiting to remove after the new one is launched")
+                logger.info("image matched, waiting to remove after the new one is launched")
                 matched_images_dict[image_coordinates(image)] = current_coordinate_image
                 images_to_remove.remove(current_coordinate_image)
             logger.debug('Appending IMAGE: {}\n\n'.format(image))

--- a/lg_media/scripts/image_viewer.py
+++ b/lg_media/scripts/image_viewer.py
@@ -16,22 +16,6 @@ from lg_common.helpers import handle_initial_state, make_soft_relaunch_callback
 from lg_common.logger import get_logger
 logger = get_logger('image_viewer')
 
-import subprocess
-
-def identify_image(image_path):
-    try:
-        result = subprocess.run(['identify', image_path], capture_output=True, text=True, check=True)
-        output_lines = result.stdout.splitlines()
-        size = None
-        for line in output_lines:
-            if ' ' in line:
-                size = line.split(' ')[2]
-                break
-        return size
-    except subprocess.CalledProcessError as e:
-        print("Error:", e)
-        return None
-
 
 def image_coordinates(image):
     return "{}_{}_{}_{}".format(image.geometry.x, image.geometry.y, image.geometry.width, image.geometry.height)

--- a/lg_media/scripts/image_viewer.py
+++ b/lg_media/scripts/image_viewer.py
@@ -38,10 +38,9 @@ class ImageViewer():
         self.viewports = viewports
         self.save_path = save_path
         self.lock = Lock()
+        self.graphic_opts = {}
 
     def director_translator(self, data):
-        global graphic_opts
-        graphic_opts = {}
         logger.error("ZZZ")
         windows_to_add = ImageViews()
         try:
@@ -76,8 +75,9 @@ class ImageViewer():
                 image.uuid = str(uuid.uuid4())
                 windows_to_add.images.append(image)
                 
-                graphic_opts[(image.url, image.geometry.x, image.geometry.y)] = {}
-                graphic_opts[(image.url, image.geometry.x, image.geometry.y)]['no_upscale'] = window.get('activity_config', {}).get('no_upscale', False)
+                self.graphic_opts[(image.url, image.geometry.x, image.geometry.y)] = {}
+                self.graphic_opts[(image.url, image.geometry.x, image.geometry.y)]['no_upscale'] = window.get('activity_config', {}).get('no_upscale', False)
+
         logger.error(f"ZZZ {windows_to_add}")
         self.handle_image_views(windows_to_add)
 
@@ -162,7 +162,7 @@ class ImageViewer():
         with open(image_path, 'wb') as f:
             f.write(r.content)
         opts = '-t'
-        if graphic_opts.get((image.url, image.geometry.x, image.geometry.y), {}).get('no_upscale', False):
+        if self.graphic_opts.get((image.url, image.geometry.x, image.geometry.y), {}).get('no_upscale', False):
             opts = ''
 
         command = '/usr/bin/pqiv -c -i {} --scale-mode-screen-fraction=1.0 -T {} -P {},{} {}'.format(


### PR DESCRIPTION
first commit builds the command adding options from asset_attributes (graphic_opts = '-t')
this way we could  add pqiv flags as needed to each asset (cms would build these asset_attributes)
Jandro pointed out the possibility of code injection, and so the next commit uses harcoded attributes/options, we could add them as needed
("upscale"=True => '-f')
