### PR TITLE
activity.py duration try avoid errors, except ignore errors

### DIFF
--- a/lg_activity/src/lg_activity/activity.py
+++ b/lg_activity/src/lg_activity/activity.py
@@ -291,14 +291,16 @@ class ActivitySource:
             return False
         if self.messages:
             try:
-                duration = int(self.messages[-1].get('message.duration', 0))  # skip to last message duration
+                duration = self.messages[-1].get('message.duration', 0)  # skip to last message duration
+                if isinstance(duration, int) or (isinstance(duration, str) and duration.isdigit()):
+                    duration = int(duration)
                 if duration > 0 and duration != 666:
                     self.messages = []
                     self.callback(self.topic, state=True, strategy='duration', delay=duration)
                     logger.info("Setting scene_duration state True delayed by %s seconds duration " % duration)
                     return True
-            except (IndexError, KeyError, ValueError, TypeError) as e:
-                logger.exception("error getting duration from message: %" % e)
+            except:
+                pass
             self.messages = []
             self.callback(self.topic, state=False, strategy='duration') 
             return False


### PR DESCRIPTION
I stil don't understand why the error was showing from a "try" block but I added "better" error handling and tested the traceback doesn't come up anymore